### PR TITLE
Update manifest config values

### DIFF
--- a/my-proof.manifest.template
+++ b/my-proof.manifest.template
@@ -2,7 +2,7 @@
 sgx.enclave_size = "256M"
 
 # Increase this as needed, e.g., if you run a web server.
-sgx.max_threads = 2
+sgx.max_threads = 4
 
 fs.mounts = [
   { type = "encrypted", path = "/sealed", uri = "file:/sealed", key_name = "_sgx_mrenclave" },


### PR DESCRIPTION
Increase `sgx.max_threads` from to 2 to 4 to resolve the issue  with no available TCS pages left for a new thread